### PR TITLE
Fix S3 bucket name, username and pull secret example - #11

### DIFF
--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -8,7 +8,7 @@ When the AWS CloudFormation template has successfully created the stack, all ser
 
 . To access the {partner-product-short-name} UI, go to the *CP4IWebClientURL* output of the root stack, as shown in <<cfn_outputs>>.
 . A new tab opens in your browser. If you configured the hostname resolution for the cluster DNS name in the URL, you see either the {partner-product-short-name} UI login page or a warning from your browser that the HTTPS connection is not safe. By default, the public key infrastructure (PKI) certificate that is created for the {partner-product-short-name} cluster is self-signed, which causes the unsafe connection warning from your browser.
-. Log in to the {partner-product-short-name} UI by using the default user admin and the password you supplied when creating the stack. If you did not supply a password, you can retrieve it from the *PlatformNavigatorPassword* secret stored in AWS Secrets Manager.
+. Log in to the {partner-product-short-name} UI by using the default user name "admin" and the password you supplied when creating the stack. If you did not supply a password, you can retrieve it from the *PlatformNavigatorPassword* secret stored in AWS Secrets Manager.
 . After you log in, the welcome page is displayed as shown in <<testStep1>>.
 +
 :xrefstyle: short

--- a/templates/ibm-cloudpak-integration.template.yaml
+++ b/templates/ibm-cloudpak-integration.template.yaml
@@ -294,7 +294,7 @@ Parameters:
     Description: Update this value if storage type is OCS. The EC2 instance type for the OpenShift Container Storage instances.
     Type: String
   RedhatPullSecret:
-    Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/portworxspec.yaml).
+    Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/pull-secret).
     Type: String
   CP4IVersion:
     Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.3 is supported.
@@ -420,7 +420,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slash (/).
-    Default: quickstart-ibm-icp-for-integration/  
+    Default: quickstart-ibm-integration/  
     Description: S3 key prefix that is used to simulate a directory for your copy of Quick Start assets. Use this if you decide to customize the Quick Start. This prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slashes (/). See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html. Unless you are customizing the template, keep the default setting. Changing this setting updates code references to point to a new Quick Start location. See https://aws-quickstart.github.io/option1.html.
     Type: String
   CP4IDeploymentLogsBucketName:

--- a/templates/ibm-cloudpak-root.template.yaml
+++ b/templates/ibm-cloudpak-root.template.yaml
@@ -301,7 +301,7 @@ Parameters:
     Description: Update this value if storage type is OCS. The EC2 instance type for the OpenShift Container Storage instances.
     Type: String
   RedhatPullSecret:
-    Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/portworxspec.yaml).
+    Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/pull-secret).
     Type: String
   CP4IVersion:
     Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.3 is supported.
@@ -427,7 +427,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slash (/).
-    Default: quickstart-ibm-icp-for-integration/  
+    Default: quickstart-ibm-integration/  
     Description: S3 key prefix that is used to simulate a directory for your copy of Quick Start assets. Use this if you decide to customize the Quick Start. This prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slashes (/). See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html. Unless you are customizing the template, keep the default setting. Changing this setting updates code references to point to a new Quick Start location. See https://aws-quickstart.github.io/option1.html.
     Type: String
   CP4IDeploymentLogsBucketName:


### PR DESCRIPTION
(cherry picked from commit 4119dd351f440b3fa20827b6ee4efda5226dc03c)

*Issue #, if available:*
#11 

*Description of changes:*
- Update default value for S3 bucket name
- Fix confusing description/example for Red Hat pull secret field
- Clarify "admin" is the actual username by adding quotes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
