### PR TITLE
Remove erroneous Cognos from two field descriptions

### DIFF
--- a/templates/ibm-cloudpak-integration.template.yaml
+++ b/templates/ibm-cloudpak-integration.template.yaml
@@ -382,7 +382,7 @@ Parameters:
     Default: "False"
   ES:
     Description: >-
-       Choose "True" to install an example instance of the Cognos Event Streaming runtime.
+       Choose "True" to install an example instance of the Event Streaming runtime.
     Type: String
     AllowedValues:
       - "False"
@@ -390,7 +390,7 @@ Parameters:
     Default: "False"
   GW:
     Description: >-
-       Choose "True" to install an example instance of the Cognos Gateway service.
+       Choose "True" to install an example instance of the Gateway service.
     Type: String
     AllowedValues:
       - "False"

--- a/templates/ibm-cloudpak-root.template.yaml
+++ b/templates/ibm-cloudpak-root.template.yaml
@@ -389,7 +389,7 @@ Parameters:
     Default: "False"
   ES:
     Description: >-
-       Choose "True" to install an example instance of the Cognos Event Streaming runtime.
+       Choose "True" to install an example instance of the Event Streaming runtime.
     Type: String
     AllowedValues:
       - "False"
@@ -397,7 +397,7 @@ Parameters:
     Default: "False"
   GW:
     Description: >-
-       Choose "True" to install an example instance of the Cognos Gateway service.
+       Choose "True" to install an example instance of the Gateway service.
     Type: String
     AllowedValues:
       - "False"


### PR DESCRIPTION
*Issue #, if available:*
No issue.

*Description of changes:*
While demoing to a colleague they noticed that the field description of the "ES" and "GW" fields incorrectly includes the word "Cognos", which is presumably left over from the copy that was taken from CP4D.

I couldn't find another other files where the word "Cognos" appears in this repo, so I assume the Deployment Guide content is generated from the templates?



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
