### PR TITLE
Update deployment guide description to state CP4I 2020.4

### DIFF
--- a/templates/ibm-cloudpak-integration.template.yaml
+++ b/templates/ibm-cloudpak-integration.template.yaml
@@ -297,7 +297,7 @@ Parameters:
     Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/pull-secret).
     Type: String
   CP4IVersion:
-    Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.3 is supported.
+    Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.4 is supported.
     Type: String
     AllowedValues:
       - 2020.4

--- a/templates/ibm-cloudpak-root.template.yaml
+++ b/templates/ibm-cloudpak-root.template.yaml
@@ -304,7 +304,7 @@ Parameters:
     Description: Your Red Hat Network (RHN) pull secret (e.g., s3://my-bucket/path/to/pull-secret).
     Type: String
   CP4IVersion:
-    Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.3 is supported.
+    Description: The version of IBM Cloud Pak for Integration to be deployed. Currently only 2020.4 is supported.
     Type: String
     AllowedValues:
       - 2020.4


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Minor tweak to state "2020.4" in the text description as well as in the technical field definition, which was picked up by a user.

I also observed that the Deployment Guide hasn't picked up the change of default value (to "2020.4") that was made a few weeks ago so I think that needs re-generating from the source once this is merged please?
<img width="1429" alt="Screenshot 2021-04-12 at 10 55 46" src="https://user-images.githubusercontent.com/32040584/114376586-a5cfac00-9b7d-11eb-8bc2-ada618a2f84f.png">

(cc @DavidMGreen for info)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
